### PR TITLE
Heat transfer corrections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hydrogen_pfhx"
-version = "0.1.6"
+version = "0.1.7"
 description = "Chemical engineering model of hydrogen plate-fin heat exchanger"
 readme = "README.md"
 keywords = ['hydrogen','pfhx','heat exchanger','ortho','para','engineering']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "CoolProp >=6.4.1",
-    "matplotlib >=3.5.2",
+    "matplotlib >=3.2.2",
     "numpy >=1.21.6",
     "pandas >=1.3.5",
     "pyyaml >=6.0",

--- a/src/hydrogen_pfhx/heat_transfer_models.py
+++ b/src/hydrogen_pfhx/heat_transfer_models.py
@@ -92,7 +92,7 @@ def full_gnielinski(Re, Pr, d, L, eta, Pr_w):
 
         Nu_turb = gnielinski_equation(f_darcy, Re, Pr, Pr_w, aspect_ratio)
         phi = (Re-2300) / (4000-2300)
-        Nu_h = phi*Nu_turb + (1-phi)*Nu_lam
+        Nu_h = phi*Nu_lam + (1-phi)*Nu_turb
     else:
         f_darcy = pressure_models.ergun_equation(eta, Re)
         Nu_h = gnielinski_equation(f_darcy, Re, Pr, Pr_w, aspect_ratio)

--- a/src/hydrogen_pfhx/hexs.py
+++ b/src/hydrogen_pfhx/hexs.py
@@ -119,13 +119,9 @@ class PlateFinHex(object):
             reactant.thermal_conductivity  # self.k_hot
 
         # wall properties
-        original_temperature = reactant.temperature
-        reactant.update_conditions(wall_temperature, reactant.pressure)
-        k_wall = self.effective_radial_conductivity(
-            reactant, catalyst, self.hydraulic_diameter())
+        k_wall = heat_transfer_models.aluminium_thermal_conductivity(wall_temperature)
         Pr_w = reactant.viscosity * reactant.specific_heat_capacity / k_wall
-        reactant.update_conditions(original_temperature, reactant.pressure)
-
+        
         # Reynolds number
         reactant.calculate_reynolds_number(catalyst.particle_diameter)
         Re = reactant.reynolds_number
@@ -149,7 +145,7 @@ class PlateFinHex(object):
             Nu_turb = heat_transfer_models.gnielinski_equation(
                 f_darcy, Re, Pr_eff, Pr_w, aspect_ratio)
             phi = 4/3 - Re/6000
-            Nu_h = phi*Nu_turb + (1-phi)*Nu_lam
+            Nu_h = phi*Nu_lam + (1-phi)*Nu_turb
         else:
             f_darcy = pressure_models.ergun_equation(
                 catalyst.void_fraction, Re)

--- a/tests/default_configuration.yaml
+++ b/tests/default_configuration.yaml
@@ -15,7 +15,7 @@ coolant:
 reactor:
     length: 6.0             # m
     width: 1.5              # m
-    height: 2.67             # m
+    height: 2.0             # m
     fin_thickness: 0.4e-3   # m
     fin_height: 6.0e-3      # m
     fin_pitch: 1.5e-3       # m

--- a/tests/default_configuration.yaml
+++ b/tests/default_configuration.yaml
@@ -14,8 +14,8 @@ coolant:
 
 reactor:
     length: 6.0             # m
-    width: 2.0              # m
-    height: 2.0             # m
+    width: 1.5              # m
+    height: 2.67             # m
     fin_thickness: 0.4e-3   # m
     fin_height: 6.0e-3      # m
     fin_pitch: 1.5e-3       # m

--- a/tests/test_model.ipynb
+++ b/tests/test_model.ipynb
@@ -31,7 +31,7 @@
         "    },\n",
         "    'reactor': {\n",
         "        'length': 6.0,             # m\n",
-        "        'width': 2.0,              # m\n",
+        "        'width': 1.5,              # m\n",
         "        'height': 2.0,             # m\n",
         "        'fin_thickness': 0.4e-3,   # m\n",
         "        'fin_height': 6.0e-3,      # m\n",


### PR DESCRIPTION
- correct nusselt number interpolation
- correct wall heat transfer usage
- default PFHX width & height
- matplotlib version (3.2.2 for colab)